### PR TITLE
GUI Assignment Builder - `step` query parameter

### DIFF
--- a/components/GuiBuilder/GuiBuilder.tsx
+++ b/components/GuiBuilder/GuiBuilder.tsx
@@ -41,7 +41,7 @@ function GUIAssignmentBuilder({ data, configId: configIdProp }: GUIAssignmentBui
   const configId = useStoreState((state) => state.config.configId);
   const isEdited = useStoreState((state) => state.config.isEdited);
   const isPipelineLayoutValid = useStoreState((state) => state.config.isPipelineLayoutValid);
-  const step = useStoreState((state) => state.layout.step);
+  const stepIndex = useStoreState((state) => state.layout.stepIndex);
 
   const initializeAssignment = useStoreActions((actions) => actions.config.initializeAssignment);
   const getConfigsToSave = useStoreActions((actions) => actions.config.getConfigsToSave);
@@ -68,7 +68,7 @@ function GUIAssignmentBuilder({ data, configId: configIdProp }: GUIAssignmentBui
 
   const isNewAssignment = configId === null;
   const disableSave = !isNewAssignment && !isEdited.any;
-  const StepComponent = guiBuilderSteps[step].component;
+  const StepComponent = guiBuilderSteps[stepIndex].component;
 
   useHotkeys([
     [

--- a/components/GuiBuilder/GuiBuilder.tsx
+++ b/components/GuiBuilder/GuiBuilder.tsx
@@ -3,7 +3,7 @@ import { Spinner } from "@/components/Spinner";
 import { useLayoutDispatch } from "@/contexts/layout";
 import { useZinc } from "@/contexts/zinc";
 import { CREATE_ASSIGNMENT_CONFIG, UPDATE_ASSIGNMENT_CONFIG } from "@/graphql/mutations/user";
-import { useHighlightElement, useWarnUnsavedChanges } from "@/hooks/GuiBuilder";
+import { useHighlightElement, useQueryParameters, useWarnUnsavedChanges } from "@/hooks/GuiBuilder";
 import { useStoreActions, useStoreState } from "@/store/GuiBuilder";
 import { Assignment, AssignmentConfig } from "@/types/tables";
 import { useMutation } from "@apollo/client";
@@ -65,6 +65,9 @@ function GUIAssignmentBuilder({ data, configId: configIdProp }: GUIAssignmentBui
       config: data?.assignmentConfig ?? null,
     });
   }, [data, configIdProp, initializeAssignment]);
+
+  const { initializeStateFromQueryParams } = useQueryParameters();
+  initializeStateFromQueryParams();
 
   const isNewAssignment = configId === null;
   const disableSave = !isNewAssignment && !isEdited.any;

--- a/components/GuiBuilder/Settings/PipelineSettings.tsx
+++ b/components/GuiBuilder/Settings/PipelineSettings.tsx
@@ -2,7 +2,6 @@ import { Checkbox, NumberInput, Select, SelectItem, SwitchGroup, TextInput } fro
 import ListInput from "@/components/Input/ListInput";
 import { highlightableElementIds } from "@/constants/GuiBuilder/highlightableElements";
 import supportedLanguages from "@/constants/GuiBuilder/supportedLanguages";
-import supportedStages from "@/constants/GuiBuilder/supportedStages";
 import { useStoreActions, useStoreState } from "@/store/GuiBuilder";
 import { SettingsFeatures, SettingsGpuDevice, SettingsUseTemplate } from "@/types/GuiBuilder";
 import { settingsLangToString } from "@/utils/GuiBuilder";
@@ -70,7 +69,6 @@ const gpuVendorSelectOptions = [
 
 function PipelineSettings() {
   const _settings = useStoreState((state) => state.config.editingConfig._settings);
-  const setStep = useStoreActions((actions) => actions.layout.setStep);
   const updateSettings = useStoreActions((actions) => actions.config.updateSettings);
 
   return (
@@ -196,11 +194,7 @@ function PipelineSettings() {
                 <p>To upload your files:</p>
                 <ol className="ml-6 list-decimal">
                   <li>
-                    Visit the{" "}
-                    <button onClick={() => setStep("upload")} className="text-blue-600 underline">
-                      Upload Files
-                    </button>{" "}
-                    step
+                    Visit the <span className="font-semibold">Upload Files</span> step
                   </li>
                   <li>
                     Upload your files under{" "}
@@ -361,26 +355,12 @@ const LangVersionTooltip = memo(() => (
 LangVersionTooltip.displayName = "LangVersionTooltip";
 
 const UseTemplateTooltip = memo(() => {
-  const setStep = useStoreActions((actions) => actions.layout.setStep);
-  const setAccordion = useStoreActions((actions) => actions.layout.setAccordion);
-  const setAddStageSearchString = useStoreActions((actions) => actions.layout.setAddStageSearchString);
-
   return (
     <InfoTooltip width={520}>
       <p>
         To perform the actual checking, add the &quot;
-        <span className="font-semibold">File Structure Validation</span>&quot; stage in your{" "}
-        <button
-          onClick={() => {
-            setStep("pipeline");
-            setAccordion({ path: "addNewStage", value: ["preCompile"] });
-            setAddStageSearchString(supportedStages.FileStructureValidation.nameInUI);
-          }}
-          className="underline text-blue-700"
-        >
-          grading pipeline
-        </button>
-        .
+        <span className="font-semibold">File Structure Validation</span>&quot; stage to your grading pipeline in the{" "}
+        <span className="font-semibold">Pipeline Stages</span> step later.
       </p>
     </InfoTooltip>
   );

--- a/components/GuiBuilder/StageSettings/DiffWithSkeletonSettings.tsx
+++ b/components/GuiBuilder/StageSettings/DiffWithSkeletonSettings.tsx
@@ -1,6 +1,5 @@
 import { SwitchGroup } from "@/components/Input";
 import { useSelectedStageConfig } from "@/hooks/GuiBuilder";
-import { useStoreActions } from "@/store/GuiBuilder";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const excludeFromProvidedLabel = (
@@ -23,7 +22,6 @@ const excludeFromProvidedDesc = (
 
 function DiffWithSkeletonSettings() {
   const [config, setConfig] = useSelectedStageConfig("DiffWithSkeleton");
-  const setStep = useStoreActions((actions) => actions.layout.setStep);
 
   if (!config) return null;
 
@@ -32,14 +30,8 @@ function DiffWithSkeletonSettings() {
       <div className="flex items-center text-blue-500 gap-4">
         <FontAwesomeIcon icon={["far", "circle-info"]} />
         <p>
-          Skeleton files are specified in the{" "}
-          <button
-            onClick={() => setStep("upload")}
-            className="border-b border-blue-600 text-blue-600 font-medium leading-5"
-          >
-            Upload Files
-          </button>{" "}
-          step &gt; &quot;Files gave to the students&quot;.
+          Skeleton files are specified in the <span className="font-semibold">Upload Files</span> step &gt; &quot;Files
+          gave to the students&quot;.
         </p>
       </div>
       <div className="mt-6">

--- a/components/GuiBuilder/StageSettings/FileStructureValidationSettings.tsx
+++ b/components/GuiBuilder/StageSettings/FileStructureValidationSettings.tsx
@@ -1,6 +1,6 @@
 import Button from "@/components/Button";
 import ListInput from "@/components/Input/ListInput";
-import { useSelectedStageConfig } from "@/hooks/GuiBuilder";
+import { useQueryParameters, useSelectedStageConfig } from "@/hooks/GuiBuilder";
 import { useStoreActions } from "@/store/GuiBuilder";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useState } from "react";
@@ -9,8 +9,9 @@ import { InfoAccordion } from "./common";
 
 function FileStructureValidationSettings() {
   const [config, setConfig] = useSelectedStageConfig("FileStructureValidation");
+  const { updateStep } = useQueryParameters();
+
   const setElementToHighlight = useStoreActions((actions) => actions.layout.setElementToHighlight);
-  const setStep = useStoreActions((actions) => actions.layout.setStep);
 
   const [ignoredFiles, setIgnoredFiles] = useState<{ id: string; name: string }[]>(
     config?.ignore_in_submission?.map((name) => ({ id: uuidv4(), name })) ?? [],
@@ -142,7 +143,7 @@ function FileStructureValidationSettings() {
           <Button
             icon={<FontAwesomeIcon icon={["fas", "compass"]} />}
             onClick={() => {
-              setStep("settings");
+              updateStep("settings");
               setElementToHighlight("useTemplate");
             }}
             className="border border-cse-600 text-cse-600 hover:bg-blue-100 active:bg-blue-200"

--- a/components/GuiBuilder/StageSettings/StdioTestSettings/StdioTestCaseSettings.tsx
+++ b/components/GuiBuilder/StageSettings/StdioTestSettings/StdioTestCaseSettings.tsx
@@ -473,25 +473,23 @@ interface HelperFileInputCardProps {
  * A card for users to input the helper file name in "Standard input" and "Expected output".
  */
 function HelperFileInputCard({ value, onChange, placeholder }: HelperFileInputCardProps) {
-  const setStep = useStoreActions((actions) => actions.layout.setStep);
   return (
-    <div className="mb-3 mx-2 p-3 bg-gray-50 rounded-lg drop-shadow">
-      <ol className="pl-4 mb-2 text-gray-600 text-sm list-decimal">
-        <li>
-          Upload the helper file to{" "}
-          <button onClick={() => setStep("upload")} className="underline text-blue-700">
-            Additional files used for grading
-          </button>
-        </li>
-        <li>Input the helper file name below:</li>
-      </ol>
+    <div className="mb-3 mx-2 p-3 bg-gray-50 rounded-lg text-gray-600 text-sm drop-shadow">
+      <label htmlFor="file_stdin">Helper file name:</label>
       <TextInput
         id="file_stdin"
         value={value}
         onChange={onChange}
         placeholder={placeholder}
-        classNames={{ root: "ml-4", input: "font-mono" }}
+        classNames={{ root: "mt-2", input: "font-mono" }}
       />
+      <div className="mt-3 text-blue-500 flex items-center gap-2">
+        <FontAwesomeIcon icon={["far", "circle-info"]} />
+        <p>
+          Helper files should be uploaded later in the <span className="font-semibold">Upload Files</span> step &gt;
+          &quot;Additional files used for grading&quot;
+        </p>
+      </div>
     </div>
   );
 }

--- a/components/GuiBuilder/Steps/LockedStep.tsx
+++ b/components/GuiBuilder/Steps/LockedStep.tsx
@@ -1,5 +1,5 @@
 import Button from "@/components/Button";
-import { useStoreActions } from "@/store/GuiBuilder";
+import { useQueryParameters } from "@/hooks/GuiBuilder";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 /**
@@ -7,7 +7,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
  * a non-null config ID to work properly.
  */
 function LockedStep() {
-  const setStep = useStoreActions((actions) => actions.layout.setStep);
+  const { updateStep } = useQueryParameters();
 
   return (
     <div className="mt-20 flex flex-col items-center">
@@ -19,7 +19,7 @@ function LockedStep() {
       </div>
       <Button
         className="mt-12 bg-cse-500 text-white hover:bg-cse-600 active:bg-cse-700"
-        onClick={() => setStep("settings")}
+        onClick={() => updateStep("settings")}
       >
         Back to General Settings
       </Button>

--- a/components/GuiBuilder/Steps/Stepper.tsx
+++ b/components/GuiBuilder/Steps/Stepper.tsx
@@ -62,12 +62,12 @@ interface StepperProps {
 function Stepper({ className = "" }: StepperProps) {
   const { classes } = useStyles();
   const configId = useStoreState((state) => state.config.configId);
-  const step = useStoreState((state) => state.layout.step);
+  const stepIndex = useStoreState((state) => state.layout.stepIndex);
   const setStep = useStoreActions((actions) => actions.layout.setStep);
 
   return (
     <StepperMantine
-      active={step}
+      active={stepIndex}
       onStepClick={(stepIndex) => setStep(guiBuilderSteps[stepIndex].slug)}
       iconSize={36}
       orientation="horizontal"

--- a/components/GuiBuilder/Steps/Stepper.tsx
+++ b/components/GuiBuilder/Steps/Stepper.tsx
@@ -1,4 +1,5 @@
-import { useStoreActions, useStoreState } from "@/store/GuiBuilder";
+import { useQueryParameters } from "@/hooks/GuiBuilder";
+import { useStoreState } from "@/store/GuiBuilder";
 import { createStyles, Stepper as StepperMantine } from "@mantine/core";
 import { memo } from "react";
 import guiBuilderSteps from "./GuiBuilderSteps";
@@ -63,12 +64,13 @@ function Stepper({ className = "" }: StepperProps) {
   const { classes } = useStyles();
   const configId = useStoreState((state) => state.config.configId);
   const stepIndex = useStoreState((state) => state.layout.stepIndex);
-  const setStep = useStoreActions((actions) => actions.layout.setStep);
+
+  const { updateStep } = useQueryParameters();
 
   return (
     <StepperMantine
       active={stepIndex}
-      onStepClick={(stepIndex) => setStep(guiBuilderSteps[stepIndex].slug)}
+      onStepClick={(stepIndex) => updateStep(guiBuilderSteps[stepIndex].slug)}
       iconSize={36}
       orientation="horizontal"
       classNames={classes}

--- a/hooks/GuiBuilder/__tests__/useQueryParameters.test.ts
+++ b/hooks/GuiBuilder/__tests__/useQueryParameters.test.ts
@@ -1,0 +1,41 @@
+import { GuiBuilderStepSlug } from "@/components/GuiBuilder/Steps/GuiBuilderSteps";
+import { getThreeStageModel } from "@/store/GuiBuilder/__tests__/utils/storeTestUtils";
+import { act } from "@testing-library/react-hooks";
+import { createStore } from "easy-peasy";
+import mockRouter from "next-router-mock";
+import useQueryParameters from "../useQueryParameters";
+import renderHookWithStore from "./utils/renderHookWithStore";
+
+// See https://github.com/scottrippey/next-router-mock
+jest.mock("next/router", () => require("next-router-mock"));
+
+describe("GuiBuilder: useQueryParameters()", () => {
+  test("initializeStateFromQueryParams()", () => {
+    const step: GuiBuilderStepSlug = "pipeline";
+    mockRouter.push(`/assignments/1/configs/1/gui?step=${step}`);
+
+    const model = getThreeStageModel();
+    const store = createStore(model);
+
+    const { result } = renderHookWithStore(store, () => useQueryParameters());
+    const { initializeStateFromQueryParams } = result.current;
+    act(() => initializeStateFromQueryParams());
+
+    expect(store.getState().layout.step).toBe(step);
+  });
+
+  test("updateStep()", () => {
+    mockRouter.push(`/assignments/1/configs/1/gui?step=settings`);
+
+    const model = getThreeStageModel();
+    const store = createStore(model);
+
+    const { result } = renderHookWithStore(store, () => useQueryParameters());
+    const { updateStep } = result.current;
+    const stepNew: GuiBuilderStepSlug = "pipeline";
+    act(() => updateStep(stepNew));
+
+    expect(store.getState().layout.step).toBe(stepNew);
+    expect(mockRouter.query.step).toBe(stepNew);
+  });
+});

--- a/hooks/GuiBuilder/index.ts
+++ b/hooks/GuiBuilder/index.ts
@@ -1,5 +1,7 @@
 export { default as useHighlightElement } from "./useHighlightElement";
 export { default as usePipelineEditorHotKeys } from "./usePipelineEditorHotKeys";
+export * from "./useQueryParameters";
+export { default as useQueryParameters } from "./useQueryParameters";
 export { default as useReactFlowFitView } from "./useReactFlowFitView";
 export { default as useSelectedStageConfig } from "./useSelectedStageConfig";
 export { default as useWarnUnsavedChanges } from "./useWarnUnsavedChanges";

--- a/hooks/GuiBuilder/useQueryParameters.ts
+++ b/hooks/GuiBuilder/useQueryParameters.ts
@@ -1,0 +1,51 @@
+import guiBuilderSteps, { GuiBuilderStepSlug } from "@/components/GuiBuilder/Steps/GuiBuilderSteps";
+import { useStoreActions } from "@/store/GuiBuilder";
+import { useRouter } from "next/router";
+import { useState } from "react";
+
+/**
+ * Query parameters used by the GUI Assignment Builder.
+ */
+export type GuiBuilderQueryParams = {
+  /** Which step is the user in. It should equal to a value from {@link GuiBuilderStepSlug}. */
+  step?: string;
+};
+
+/**
+ * Returns utility functions for synchronizing the page's query parameters with the GUI Assignment
+ * Builder's store state.
+ */
+function useQueryParameters() {
+  const router = useRouter();
+  const setStep = useStoreActions((actions) => actions.layout.setStep);
+
+  const [isFirstLoad, setIsFirstLoad] = useState(true);
+
+  return {
+    /**
+     * When the user first enters the page, use the query parameters to initialize the store state.
+     */
+    initializeStateFromQueryParams: () => {
+      if (!isFirstLoad) return;
+
+      if (guiBuilderSteps.some((s) => s.slug === router.query.step)) {
+        setStep(router.query.step as GuiBuilderStepSlug);
+      }
+
+      setIsFirstLoad(false);
+    },
+
+    /**
+     * Changes which step the user is in by updating both the store state and the `step` query parameter.
+     */
+    updateStep: (step: GuiBuilderStepSlug) => {
+      setStep(step);
+      router.replace({
+        pathname: router.pathname,
+        query: { ...router.query, step },
+      });
+    },
+  };
+}
+
+export default useQueryParameters;

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "jest-environment-jsdom": "^29.2.2",
     "jest-extended": "^3.1.0",
     "lint-staged": "^13.0.3",
+    "next-router-mock": "^0.9.2",
     "postcss": "^8.4.16",
     "postcss-preset-env": "^6.7.0",
     "prettier": "^2.7.1",

--- a/store/GuiBuilder/__tests__/layoutModel.test.ts
+++ b/store/GuiBuilder/__tests__/layoutModel.test.ts
@@ -2,11 +2,9 @@ import { createStore } from "easy-peasy";
 import { layoutModel } from "../model/layoutModel";
 
 describe("GuiBuilder: Store - LayoutModel", () => {
-  describe("setStep()", () => {
-    it("sets the step given its slug", () => {
-      const store = createStore(layoutModel);
-      store.getActions().setStep("settings");
-      expect(store.getState().step).toEqual(0);
-    });
+  test("stepIndex", () => {
+    const store = createStore(layoutModel);
+    store.getActions().setStep("pipeline");
+    expect(store.getState().stepIndex).toEqual(1);
   });
 });

--- a/store/GuiBuilder/model/layoutModel.ts
+++ b/store/GuiBuilder/model/layoutModel.ts
@@ -1,6 +1,6 @@
 import guiBuilderSteps, { GuiBuilderStepSlug } from "@/components/GuiBuilder/Steps/GuiBuilderSteps";
 import { HighlightableElementsKey } from "@/constants/GuiBuilder/highlightableElements";
-import { action, Action } from "easy-peasy";
+import { action, Action, Computed, computed } from "easy-peasy";
 import set from "lodash/set";
 
 // #region Model Definition
@@ -8,11 +8,11 @@ import set from "lodash/set";
 /**
  * Model for the layout-related states in the GUI Assignment Builder.
  */
-export type LayoutModel = LayoutModelState & LayoutModelAction;
+export type LayoutModel = LayoutModelState & LayoutModelComputed & LayoutModelAction;
 
 interface LayoutModelState {
-  /** Zero-based index of which step the user is in. */
-  step: number;
+  /** Slug of which step the user is in. */
+  step: GuiBuilderStepSlug;
   /** Which accordion components are opened. */
   accordion: AccordionState;
   /** Which alerts are shown. */
@@ -25,6 +25,11 @@ interface LayoutModelState {
   isAddStageCollapsed: boolean;
   /** Which element on the page should be highlighted. */
   elementToHighlight?: HighlightableElementsKey;
+}
+
+interface LayoutModelComputed {
+  /** Zero-based index of which step the user is in. */
+  stepIndex: Computed<LayoutModel, number>;
 }
 
 interface LayoutModelAction {
@@ -86,7 +91,7 @@ export interface ModalState {
 // #region Model Implementation
 
 const layoutModelState: LayoutModelState = {
-  step: 0,
+  step: "settings",
   accordion: {
     addNewStage: ["preCompile", "compile", "grading", "miscStages"],
   },
@@ -104,9 +109,15 @@ const layoutModelState: LayoutModelState = {
   isAddStageCollapsed: false,
 };
 
+const layoutModelComputed: LayoutModelComputed = {
+  stepIndex: computed((state) => {
+    return guiBuilderSteps.findIndex((step) => step.slug === state.step);
+  }),
+};
+
 const layoutModelAction: LayoutModelAction = {
   setStep: action((state, stepSlug) => {
-    state.step = guiBuilderSteps.findIndex((step) => step.slug === stepSlug);
+    state.step = stepSlug;
   }),
   setAccordion: action((state, payload) => {
     set(state.accordion, payload.path, payload.value);
@@ -130,6 +141,7 @@ const layoutModelAction: LayoutModelAction = {
 
 export const layoutModel: LayoutModel = {
   ...layoutModelState,
+  ...layoutModelComputed,
   ...layoutModelAction,
 };
 

--- a/store/GuiBuilder/model/layoutModel.ts
+++ b/store/GuiBuilder/model/layoutModel.ts
@@ -1,5 +1,6 @@
 import guiBuilderSteps, { GuiBuilderStepSlug } from "@/components/GuiBuilder/Steps/GuiBuilderSteps";
 import { HighlightableElementsKey } from "@/constants/GuiBuilder/highlightableElements";
+import { useQueryParameters } from "@/hooks/GuiBuilder";
 import { action, Action, Computed, computed } from "easy-peasy";
 import set from "lodash/set";
 
@@ -33,6 +34,12 @@ interface LayoutModelComputed {
 }
 
 interface LayoutModelAction {
+  /**
+   * Do **NOT** call this directly to change the step. Instead, use `updateStep()` from
+   * {@link useQueryParameters} to update which step the user is in.
+   *
+   * This is because calling this directly will not update the `step` query parameter.
+   */
   setStep: Action<LayoutModel, GuiBuilderStepSlug>;
   setAccordion: Action<
     LayoutModel,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7921,6 +7921,11 @@ negotiator@0.6.2:
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
+next-router-mock@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/next-router-mock/-/next-router-mock-0.9.2.tgz#750341ea0bab9fa04257fb38a85bbe5c25dc19e5"
+  integrity sha512-rh6Mq1xhZ4Y0y9Z3seHZ04k4dAKnAyRcis7q3ZUF+Xp0uBeNqPC8Ydw5DldYncN3o1sYBqRyz25F/v/kfcg0/Q==
+
 next@^12.0.1:
   version "12.0.7"
   resolved "https://registry.npmjs.org/next/-/next-12.0.7.tgz"


### PR DESCRIPTION
# Description

This PR adds a new query parameter called `step` to GUI Assignment Builder's URL.

For example, when a user visits `/assignments/1/configs/1/gui?step=pipeline`, the page will show the user in the "Pipeline Stages" step instead of the first step ("General Settings").